### PR TITLE
Update article titles across index, news, and news-archive pages to r…

### DIFF
--- a/index.php
+++ b/index.php
@@ -500,7 +500,7 @@ include('header.php'); ?>
                 <div class="news-item">
                     <a href="biotech-veteran-and-virologist-joins-cancervax-as-senior-scientific-advisor.php"></a>
                     <span>January 27, 2026</span>
-                    <h3>World-renowned Immunologist and Distinguished Scientist Joins CancerVax as Senior Scientific Advisor</h3>
+                    <h3>Biotech Veteran and Virologist Joins CancerVax as Senior Scientific Advisor</h3>
                     <p>CancerVax, Inc., the developer of a breakthrough universal cancer treatment platform that uses the body’s immune system to treat cancer, today announced that George Kemble, PhD will serve as a Senior Scientific Advisor</p>
                 </div>
             </div>

--- a/news-archive.php
+++ b/news-archive.php
@@ -19,7 +19,7 @@ include('header.php'); ?>
                 <div class="news-item">
                     <a href="biotech-veteran-and-virologist-joins-cancervax-as-senior-scientific-advisor.php"></a>
                     <span>January 27, 2026</span>
-                    <h3>World-renowned Immunologist and Distinguished Scientist Joins CancerVax as Senior Scientific Advisor</h3>
+                    <h3>Biotech Veteran and Virologist Joins CancerVax as Senior Scientific Advisor</h3>
                     <p>CancerVax, Inc., the developer of a breakthrough universal cancer treatment platform that uses the body’s immune system to treat cancer, today announced that George Kemble, PhD will serve as a Senior Scientific Advisor</p>
                 </div>
             </div>

--- a/news.php
+++ b/news.php
@@ -19,7 +19,7 @@ include('header.php'); ?>
                 <div class="news-item">
                     <a href="biotech-veteran-and-virologist-joins-cancervax-as-senior-scientific-advisor.php"></a>
                     <span>January 27, 2026</span>
-                    <h3>World-renowned Immunologist and Distinguished Scientist Joins CancerVax as Senior Scientific Advisor</h3>
+                    <h3>Biotech Veteran and Virologist Joins CancerVax as Senior Scientific Advisor</h3>
                     <p>CancerVax, Inc., the developer of a breakthrough universal cancer treatment platform that uses the body’s immune system to treat cancer, today announced that George Kemble, PhD will serve as a Senior Scientific Advisor</p>
                 </div>
             </div>


### PR DESCRIPTION
…eflect Dr. George Kemble's correct title as "Biotech Veteran and Virologist" joining CancerVax as Senior Scientific Advisor, ensuring consistency and accuracy in the presentation of leadership announcements.